### PR TITLE
Release 1.0.5

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -2,7 +2,7 @@
 #
 # project version
 #
-tpfrVersion = "1.0.5-SNAPSHOT"
+tpfrVersion = "1.0.5"
 #
 # dependency versions
 #

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -2,7 +2,7 @@
 #
 # project version
 #
-tpfrVersion = "1.0.5"
+tpfrVersion = "1.0.6-SNAPSHOT"
 #
 # dependency versions
 #

--- a/project_files/owasp/dependency-check-suppression.xml
+++ b/project_files/owasp/dependency-check-suppression.xml
@@ -15,4 +15,15 @@
     <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
     <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      file name: jackson-databind-2.15.2.jar
+      reason: DISPUTED: the vendor's perspective is that this is not a valid vulnerability report, because
+              the steps of constructing a cyclic data structure and trying to serialize it cannot be
+              achieved by an external attacker. See:
+              https://github.com/FasterXML/jackson-databind/issues/3972
+      ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>CVE-2023-35116</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
* ESCP-4176:suppress CVE-2023-35116 for jackson-databind
* 1.0.5 release
* Begin work on 1.0.6-SNAPSHOT